### PR TITLE
[FIX] remove a checkbox do dia inteiro no schedule do aluno

### DIFF
--- a/web/app/students/[id]/class-schedule/page.tsx
+++ b/web/app/students/[id]/class-schedule/page.tsx
@@ -297,17 +297,6 @@ export default function ClassSchedulePage() {
     setSelectedSeries(prev=> prev.includes(seriesId)? prev.filter(i=> i!==seriesId): canSelectSeries(seriesId)? [...prev, seriesId]: prev)
   }
 
-  const toggleDay = (weekday: number) => {
-    setInitializedSelection(true)
-    const ids = filteredSeries.filter(s => s.weekday === weekday).map(s => s.id)
-    const anySelected = ids.some(id => selectedSeries.includes(id))
-    if(anySelected){
-      setSelectedSeries(prev=> prev.filter(id=> !ids.includes(id)))
-    } else if(selectedDays.length < planDays) {
-      setSelectedSeries(prev=> [...prev, ...ids.filter(id => !prev.includes(id))])
-    }
-  }
-
   const handleSave = async () => {
     // Determine adds/removals
     // Determine latest active ATTENDING set from activeCommitmentsQuery (already filtered server-side)
@@ -411,7 +400,6 @@ export default function ClassSchedulePage() {
                 <CardHeader className="pb-3">
                   <div className="flex items-center justify-between">
                     <CardTitle className="text-base flex items-center gap-2">
-                      <Checkbox checked={isDaySelected} onCheckedChange={()=> toggleDay(day.weekday)} disabled={!canSelectDay && !isDaySelected}/>
                       <Calendar className="w-4 h-4"/> {day.day}
                     </CardTitle>
                     <Badge variant="outline" className="text-xs">{day.classes.length} séries</Badge>


### PR DESCRIPTION
Na UI atual temos um checkbox que representa o dia inteiro de treinos na schedule de um aluno:
<img width="259" height="111" alt="image" src="https://github.com/user-attachments/assets/61f986e6-014b-4e5e-9722-02bc94f2dbf1" />

Esse checkbox não precisa existir, já que o use case dele é inviável para um aluno da academia, quando selecionamos a checkbox ele automaticamente gera conflitos por causa dos horários disponíveis da academia, então é melhor remover ele:
<img width="354" height="723" alt="image" src="https://github.com/user-attachments/assets/87c7a9ef-16d7-4854-af73-cb13efefb4cd" />

Assim, com esse fix o checkbox foi removido:
<img width="432" height="161" alt="image" src="https://github.com/user-attachments/assets/8f33845b-4b5c-4f6b-bb6c-0ea533a9a394" />
