### PR TITLE
Change hours format

### DIFF
--- a/web/components/reports/reports-page-view.tsx
+++ b/web/components/reports/reports-page-view.tsx
@@ -437,7 +437,7 @@ export function ReportsPageView() {
                       aria-hidden="true"
                     />
                   ) : (
-                    `${formatNumber(totals.hours, 1)}h`
+                    formatDurationHours(totals.hours)
                   )}
                 </p>
               </div>


### PR DESCRIPTION
Foi alterado o formato de horas exibido no card de Total de Horas. Antes era usado uma notação de fração de horas atualmente é usado em horas e minutos.